### PR TITLE
Remove a link to the demo site

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,6 @@
           <a href="https://github.com/gitbucket/gitbucket"><span class="mega-octicon octicon-mark-github octicon-btn"></span>GitHub</a>
         </li>
         <li><a href="https://gitter.im/gitbucket/gitbucket"><span class="mega-octicon octicon-comment octicon-btn"></span>Chat</a></li>
-        <li><a data-toggle="modal" data-target="#sampleModal"><span class="mega-octicon octicon-rocket octicon-btn"></span>Demo</a></li>
         <li><a href="https://gitbucket.github.io/gitbucket-news/"><span class="mega-octicon octicon-rss octicon-btn"></span>News</a></li>
         <li><a href="http://gitbucket-plugins.github.io/"><span class="mega-octicon octicon-plug octicon-btn"></span>Plugins</a></li>
       </ul>
@@ -231,26 +230,6 @@
   </footer>
 </div>
 <!-- /container -->
-
-<div class="modal fade" id="sampleModal" tabindex="-1">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal"><span>×</span></button>
-        <h4 class="modal-title">Try Demo</h4>
-      </div>
-      <div class="modal-body">
-        <p>
-          This test instance is shared across different users, so let the password, as it is, thanks.
-          The instance gets reset regularly and the username and password is <code>root</code> / <code>root</code>:
-        </p>
-        <p>
-          <a href="https://gitbucket.herokuapp.com/">https://gitbucket.herokuapp.com/</a>
-        </p>
-      </div>
-    </div>
-  </div>
-</div>
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.2.min.js"><\/script>')</script>


### PR DESCRIPTION
Heroku seems to be ending the free plan (https://blog.heroku.com/next-chapter).

Recently, I was worrying about the maintenance of our demo site hosted on Heroku. It's may be a good timing to shutdown it.